### PR TITLE
DEV: experimental - defer javascript and enable early output of interim content for LCP

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -83,6 +83,10 @@ const Discourse = Application.extend({
     });
   },
 
+  ready() {
+    document.getElementById("main-placeholder")?.remove();
+  },
+
   _registerPluginCode(version, code) {
     _pluginCallbacks.push({ version, code });
   },

--- a/app/assets/stylesheets/common/base/_index.scss
+++ b/app/assets/stylesheets/common/base/_index.scss
@@ -20,6 +20,7 @@
 @import "ember-select";
 @import "emoji";
 @import "exception";
+@import "experimental_static_topic_content";
 @import "explain-reviewable";
 @import "faqs";
 @import "group";

--- a/app/assets/stylesheets/common/base/experimental_static_topic_content.scss
+++ b/app/assets/stylesheets/common/base/experimental_static_topic_content.scss
@@ -1,0 +1,90 @@
+/*
+ * Hide placeholder on ember ready.
+ * This is an alternative to removing the placeholder via JavaScript on EmberJs Application.ready()
+ */
+//#main.ember-application + #main-placeholder {
+//  display: none;
+//  visibility: hidden;
+//}
+
+/*
+ * Static placeholder for topic view is based on crawler layout.
+ * These hacks make the layout pixel-perfectly identical to the EmberJs rendered view.
+ */
+#main-placeholder {
+  #topic-title {
+    margin-bottom: 0;
+
+    html.mobile-view & {
+      padding-top: 1.25em;
+      padding-bottom: 0;
+    }
+
+    html.desktop-view & {
+      padding-top: 2.5em;
+    }
+  }
+
+  > .wrap > .row {
+    border-left: 1px solid transparent;
+  }
+
+  .topic-body {
+    padding-top: 0;
+
+    html.desktop-view & {
+      border-top: 1px solid var(--primary-low);
+      width: $topic-body-width;
+      padding: 12px $topic-body-width-padding 0
+        ($topic-avatar-width + $topic-body-width-padding);
+    }
+  }
+
+  #topic-title + .row .topic-body {
+    /* first post */
+    /* topic footer: post-menu-area + margin + post-links-container */
+
+    html.mobile-view & {
+      padding-bottom: 37.7px + 10px + 55.1px - 25px;
+    }
+
+    html.desktop-view & {
+      padding-bottom: 33.7px + 20px + 55.9px;
+    }
+  }
+
+  .crawler-post-meta {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    html.mobile-view & {
+      width: calc(100% - #{$topic-avatar-width + 10px});
+      height: $topic-avatar-width;
+      margin-left: $topic-avatar-width + 10px;
+      margin-bottom: 10px;
+      padding-top: 15px;
+      font-size: var(--font-down-1);
+      line-height: var(--line-height-medium);
+    }
+
+    html.desktop-view & {
+      margin-bottom: 1.25em;
+      width: 100%;
+      height: 1.4em;
+    }
+  }
+
+  .creator a span {
+    color: var(--primary-high-or-secondary-low);
+
+    html.mobile-view & {
+      font-size: var(--font-0);
+    }
+  }
+
+  div.post p {
+    margin-top: 0;
+    overflow-wrap: break-word;
+  }
+}

--- a/app/assets/stylesheets/common/base/experimental_static_topic_content.scss
+++ b/app/assets/stylesheets/common/base/experimental_static_topic_content.scss
@@ -1,4 +1,16 @@
 /*
+ * Disable animations for EmberJs generated content because static content was already in place:
+ * Header menu and highlighting of first post
+ */
+html.experimental-static-topic-content {
+  .d-header .title,
+  .d-header .panel,
+  .post-stream > div:first-child .topic-body.highlighted {
+    animation: none;
+  }
+}
+
+/*
  * Hide placeholder on ember ready.
  * This is an alternative to removing the placeholder via JavaScript on EmberJs Application.ready()
  */

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -157,7 +157,7 @@ module ApplicationHelper
   end
 
   def preload_script_url(url, defer = true)
-    defer_attribute = defer ? ' defer' : ''
+    defer_attribute = (SiteSetting.enable_experimental_javascript_defer && defer) ? ' defer' : ''
     <<~HTML.html_safe
       <link rel="preload" href="#{url}" as="script">
       <script#{defer_attribute} src="#{url}"></script>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,7 +135,7 @@ module ApplicationHelper
     path
   end
 
-  def preload_vendor_scripts
+  def preload_vendor_scripts(defer = true)
     scripts = ["vendor"]
 
     if ENV["EMBER_CLI_PROD_ASSETS"] != "0"
@@ -147,19 +147,20 @@ module ApplicationHelper
     end
 
     scripts.map do |name|
-      preload_script(name)
+      preload_script(name, defer)
     end.join("\n").html_safe
   end
 
-  def preload_script(script)
+  def preload_script(script, defer = true)
     path = script_asset_path(script)
-    preload_script_url(path)
+    preload_script_url(path, defer)
   end
 
-  def preload_script_url(url)
+  def preload_script_url(url, defer = true)
+    defer_attribute = defer ? ' defer' : ''
     <<~HTML.html_safe
       <link rel="preload" href="#{url}" as="script">
-      <script src="#{url}"></script>
+      <script#{defer_attribute} src="#{url}"></script>
     HTML
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,6 +181,7 @@ module ApplicationHelper
     list << 'rtl' if rtl?
     list << text_size_class
     list << 'anon' unless current_user
+    list << 'experimental-static-topic-content' if SiteSetting.enable_experimental_static_topic_content
     list.join(' ')
   end
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -312,7 +312,8 @@ class Theme < ActiveRecord::Base
     return "" if theme_id.blank?
 
     theme_ids = !skip_transformation ? transform_ids(theme_id) : [theme_id]
-    cache_key = "#{theme_ids.join(",")}:#{target}:#{field}:#{Theme.compiler_version}"
+    cache_key_part_experimental = target == :extra_js && SiteSetting.enable_experimental_javascript_defer ? ':defer' : ''
+    cache_key = "#{theme_ids.join(",")}:#{target}:#{field}:#{Theme.compiler_version}#{cache_key_part_experimental}"
     lookup = @cache[cache_key]
     return lookup.html_safe if lookup
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -394,7 +394,7 @@ class Theme < ActiveRecord::Base
       end
       caches = JavascriptCache.where(theme_id: theme_ids)
       caches = caches.sort_by { |cache| theme_ids.index(cache.theme_id) }
-      return caches.map { |c| "<script src='#{c.url}' data-theme-id='#{c.theme_id}'></script>" }.join("\n")
+      return caches.map { |c| "<script defer src='#{c.url}' data-theme-id='#{c.theme_id}'></script>" }.join("\n")
     end
     list_baked_fields(theme_ids, target, name).map { |f| f.value_baked || f.value }.join("\n")
   end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -394,7 +394,8 @@ class Theme < ActiveRecord::Base
       end
       caches = JavascriptCache.where(theme_id: theme_ids)
       caches = caches.sort_by { |cache| theme_ids.index(cache.theme_id) }
-      return caches.map { |c| "<script defer src='#{c.url}' data-theme-id='#{c.theme_id}'></script>" }.join("\n")
+      defer_attribute = SiteSetting.enable_experimental_javascript_defer ? ' defer' : ''
+      return caches.map { |c| "<script#{defer_attribute} src='#{c.url}' data-theme-id='#{c.theme_id}'></script>" }.join("\n")
     end
     list_baked_fields(theme_ids, target, name).map { |f| f.value_baked || f.value }.join("\n")
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -142,7 +142,8 @@ class ThemeField < ActiveRecord::Base
     javascript_cache.content = js_compiler.content
     javascript_cache.save!
 
-    doc.add_child("<script defer src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>") if javascript_cache.content.present?
+    defer_attribute = SiteSetting.enable_experimental_javascript_defer ? ' defer' : ''
+    doc.add_child("<script#{defer_attribute} src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>") if javascript_cache.content.present?
     [doc.to_s, errors&.join("\n")]
   end
 
@@ -258,7 +259,8 @@ class ThemeField < ActiveRecord::Base
     javascript_cache.content = js_compiler.content
     javascript_cache.save!
     doc = ""
-    doc = "<script defer src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>" if javascript_cache.content.present?
+    defer_attribute = SiteSetting.enable_experimental_javascript_defer ? ' defer' : ''
+    doc = "<script#{defer_attribute} src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>" if javascript_cache.content.present?
     [doc, errors&.join("\n")]
   end
 

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -142,7 +142,7 @@ class ThemeField < ActiveRecord::Base
     javascript_cache.content = js_compiler.content
     javascript_cache.save!
 
-    doc.add_child("<script src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>") if javascript_cache.content.present?
+    doc.add_child("<script defer src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>") if javascript_cache.content.present?
     [doc.to_s, errors&.join("\n")]
   end
 
@@ -258,7 +258,7 @@ class ThemeField < ActiveRecord::Base
     javascript_cache.content = js_compiler.content
     javascript_cache.save!
     doc = ""
-    doc = "<script src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>" if javascript_cache.content.present?
+    doc = "<script defer src='#{javascript_cache.url}' data-theme-id='#{theme_id}'></script>" if javascript_cache.content.present?
     [doc, errors&.join("\n")]
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,6 +72,7 @@
     <%- end -%>
 
     <%= render_google_tag_manager_body_code %>
+    <% if !@topic_view %>
     <noscript data-path="<%= request.env['PATH_INFO'] %>">
       <%= render partial: 'header' %>
       <div id="main-outlet" class="wrap" role="main">
@@ -93,6 +94,7 @@
         <p><%= t 'powered_by_html' %></p>
       </footer>
     </noscript>
+    <% end %>
 
     <%- unless customization_disabled? %>
       <%= theme_lookup("header") %>
@@ -104,6 +106,34 @@
 
     <section id='main'>
     </section>
+
+    <% if @topic_view %>
+      <section id='main-placeholder'>
+        <div class='d-header-wrap'>
+          <%= render partial: 'header' %>
+        </div>
+        <div class='wrap'>
+          <!-- preload-content: -->
+          <%= yield %>
+          <!-- :preload-content -->
+        </div>
+      </section>
+
+      <noscript data-path="<%= request.env['PATH_INFO'] %>">
+        <footer class="noscript-footer-nav">
+          <nav itemscope itemtype='http://schema.org/SiteNavigationElement'>
+            <a href='<%= path "/" %>'><%= t 'home_title' %></a>
+            <%= link_to t('js.filters.categories.title'), path("/categories") %>
+            <%= link_to t('guidelines_topic.title'), path("/guidelines") %>
+            <%= link_to t('tos_topic.title'), path("/tos") %>
+            <%= link_to t('privacy_topic.title'), path("/privacy") %>
+          </nav>
+        </footer>
+        <footer id='noscript-footer'>
+          <p><%= t 'powered_by_html' %></p>
+        </footer>
+      </noscript>
+    <% end %>
 
     <% unless current_user %>
       <form id='hidden-login-form' method="post" action="<%=main_app.login_path%>" style="display: none;">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,11 +116,11 @@
 
     <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
 
-    <script src="<%= script_asset_path "start-discourse" %>"></script>
+    <script defer src="<%= script_asset_path "start-discourse" %>"></script>
 
     <%= yield :data %>
 
-    <script src="<%= script_asset_path "browser-update" %>"></script>
+    <script defer src="<%= script_asset_path "browser-update" %>"></script>
 
     <%- unless customization_disabled? %>
       <%= theme_lookup("body_tag") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,13 +23,13 @@
 
     <link rel="preload" href="<%= script_asset_path "start-discourse" %>" as="script">
     <link rel="preload" href="<%= script_asset_path "browser-update" %>" as="script">
-    <%= preload_script 'browser-detect' %>
+    <%= preload_script('browser-detect', false) %>
 
-    <%= preload_script "locales/#{I18n.locale}" %>
+    <%= preload_script("locales/#{I18n.locale}", false) %>
     <%- if ExtraLocalesController.client_overrides_exist? %>
-      <%= preload_script_url ExtraLocalesController.url('overrides') %>
+      <%= preload_script_url(ExtraLocalesController.url('overrides'), false) %>
     <%- end %>
-    <%= preload_vendor_scripts %>
+    <%= preload_vendor_scripts(false) %>
     <%= preload_script "application" %>
     <%- Discourse.find_plugin_js_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, request: request).each do |file| %>
       <%= preload_script file %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
     <%- end -%>
 
     <%= render_google_tag_manager_body_code %>
-    <% if !@topic_view %>
+    <% if !(SiteSetting.enable_experimental_static_topic_content && @topic_view) %>
     <noscript data-path="<%= request.env['PATH_INFO'] %>">
       <%= render partial: 'header' %>
       <div id="main-outlet" class="wrap" role="main">
@@ -107,7 +107,7 @@
     <section id='main'>
     </section>
 
-    <% if @topic_view %>
+    <% if SiteSetting.enable_experimental_static_topic_content && @topic_view %>
       <section id='main-placeholder'>
         <div class='d-header-wrap'>
           <%= render partial: 'header' %>
@@ -146,11 +146,11 @@
 
     <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
 
-    <script defer src="<%= script_asset_path "start-discourse" %>"></script>
+    <script<%= SiteSetting.enable_experimental_javascript_defer ? ' defer' : '' %> src="<%= script_asset_path "start-discourse" %>"></script>
 
     <%= yield :data %>
 
-    <script defer src="<%= script_asset_path "browser-update" %>"></script>
+    <script<%= SiteSetting.enable_experimental_javascript_defer ? ' defer' : '' %> src="<%= script_asset_path "browser-update" %>"></script>
 
     <%- unless customization_disabled? %>
       <%= theme_lookup("body_tag") %>

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -7,14 +7,14 @@
     <%- unless customization_disabled? %>
       <%= discourse_stylesheet_link_tag  :embedded_theme %>
     <%- end %>
-    <%= preload_script 'break_string' %>
+    <%= preload_script('break_string', false) %>
 
     <%- if @topic_view && @topic_view.page_title.present? %>
       <title><%= @topic_view.page_title %> - <%= SiteSetting.title %></title>
     <%- end %>
 
     <meta id="data-embedded" data-referer="<%= @data_referer %>">
-    <%= preload_script 'embed-application' %>
+    <%= preload_script('embed-application', false) %>
 
     <%= yield :head %>
   </head>

--- a/app/views/qunit/index.html.erb
+++ b/app/views/qunit/index.html.erb
@@ -5,16 +5,16 @@
     <%= discourse_color_scheme_stylesheets %>
     <%= discourse_stylesheet_link_tag(:desktop, theme_id: nil) %>
     <%= discourse_stylesheet_link_tag(:test_helper, theme_id: nil) %>
-    <%= preload_script "locales/#{I18n.locale}" %>
-    <%= preload_vendor_scripts %>
-    <%= preload_script "application" %>
-    <%= preload_script "admin" %>
-    <%= preload_script "discourse/tests/test-support-rails" %>
-    <%= preload_script "discourse/tests/test-helpers-rails" %>
-    <%= preload_script "discourse/tests/active-plugins" %>
-    <%= preload_script "discourse/tests/core-tests" %>
-    <%= preload_script "discourse/tests/plugin-tests" %>
-    <%= preload_script "discourse/tests/test_starter" %>
+    <%= preload_script("locales/#{I18n.locale}", false) %>
+    <%= preload_vendor_scripts(false) %>
+    <%= preload_script("application", false) %>
+    <%= preload_script("admin", false) %>
+    <%= preload_script("discourse/tests/test-support-rails", false) %>
+    <%= preload_script("discourse/tests/test-helpers-rails", false) %>
+    <%= preload_script("discourse/tests/active-plugins", false) %>
+    <%= preload_script("discourse/tests/core-tests", false) %>
+    <%= preload_script("discourse/tests/plugin-tests", false) %>
+    <%= preload_script("discourse/tests/test_starter", false) %>
     <%= csrf_meta_tags %>
     <meta property="og:title" content="">
     <meta property="og:url" content="">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -35,7 +35,7 @@
 
   <%= server_plugin_outlet "topic_header" %>
 
-  <%- if include_crawler_content? || mobile_view? %>
+  <%- if include_crawler_content? || (SiteSetting.enable_experimental_static_topic_content && mobile_view?) %>
 
   <% @topic_view.posts.each_with_index do |post, idx| %>
     <% if (u = post.user) %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -40,7 +40,6 @@
   <% @topic_view.posts.each_with_index do |post, idx| %>
     <% if (u = post.user) %>
     <div class='row'>
-      <div class='topic-avatar crawler-post' style='min-width: 55px'></div>
       <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body crawler-post'>
         <div class='crawler-post-meta'>
           <div itemprop='publisher' itemscope itemtype="http://schema.org/Organization">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,8 +1,10 @@
 <% if @topic_view %>
   <div id="topic-title">
+    <div class="title-wrapper">
     <h1>
       <%= render_topic_title(@topic_view.topic) %>
     </h1>
+    </div>
 
     <% if @breadcrumbs.present? %>
       <div class="topic-category" itemscope itemtype="http://schema.org/BreadcrumbList">
@@ -33,10 +35,12 @@
 
   <%= server_plugin_outlet "topic_header" %>
 
-  <%- if include_crawler_content? %>
+  <%- if include_crawler_content? || mobile_view? %>
 
   <% @topic_view.posts.each_with_index do |post, idx| %>
     <% if (u = post.user) %>
+    <div class='row'>
+      <div class='topic-avatar crawler-post' style='min-width: 55px'></div>
       <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body crawler-post'>
         <div class='crawler-post-meta'>
           <div itemprop='publisher' itemscope itemtype="http://schema.org/Organization">
@@ -114,6 +118,7 @@
             </div>
          <% end %>
       </div>
+    </div>
     <% end %>
   <% end %>
 

--- a/app/views/users/activate_account.html.erb
+++ b/app/views/users/activate_account.html.erb
@@ -10,9 +10,9 @@
 </div>
 
 <%- content_for(:no_ember_head) do %>
-  <%= preload_vendor_scripts %>
+  <%= preload_vendor_scripts(false) %>
   <%= render_google_universal_analytics_code %>
   <%= tag.meta id: 'data-activate-account', data: { path: path('/session/hp') } %>
 <%- end %>
 
-<%= preload_script "activate-account" %>
+<%= preload_script("activate-account", false) %>

--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -17,7 +17,7 @@
 
 <%- content_for(:no_ember_head) do %>
   <meta name="referrer" content="never">
-  <%= preload_script "ember_jquery" %>
+  <%= preload_script("ember_jquery", false) %>
   <%= render_google_universal_analytics_code %>
 <%- end %>
 

--- a/app/views/users/perform_account_activation.html.erb
+++ b/app/views/users/perform_account_activation.html.erb
@@ -16,7 +16,7 @@
       <%- content_for(:no_ember_head) do %>
         <%= tag.meta id: 'data-auto-redirect', data: { path: path('/') } %>
       <%- end %>
-      <%= preload_script 'auto-redirect' %>
+      <%= preload_script('auto-redirect', false) %>
     <% end %>
   <%end%>
 </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1773,6 +1773,9 @@ en:
 
     enable_safe_mode: "Allow users to enter safe mode to debug plugins."
 
+    enable_experimental_static_topic_content: "(Highly experimental!) Show static content in topic view for a faster Largest Contentful Paint (LCP). Warning: visitors might see disconcerting jumping of content!"
+    enable_experimental_javascript_defer: "(Highly experimental!) Defer loading of JavaScripts to show static content even faster in combination with 'enable_experimental_javascript_defer'. Warning: the discourse frontend, themes, components and/or plugins might fail!"
+
     rate_limit_create_topic: "After creating a topic, users must wait (n) seconds before creating another topic."
     rate_limit_create_post: "After posting, users must wait (n) seconds before creating another post."
     rate_limit_new_user_create_topic: "After creating a topic, new users must wait (n) seconds before creating another topic."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1944,6 +1944,11 @@ developer:
   enable_safe_mode:
     default: true
     client: true
+  enable_experimental_static_topic_content:
+    default: false
+  enable_experimental_javascript_defer:
+    default: false
+    hidden: true
 
 embedding:
   embed_by_username:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1948,7 +1948,6 @@ developer:
     default: false
   enable_experimental_javascript_defer:
     default: false
-    hidden: true
 
 embedding:
   embed_by_username:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,74 +6,110 @@ require 'rails_helper'
 describe ApplicationHelper do
 
   describe "preload_script" do
-    def preload_link(url)
-      <<~HTML
-          <link rel="preload" href="#{url}" as="script">
-          <script src="#{url}"></script>
-      HTML
-    end
-
-    it "provides brotli links to brotli cdn" do
-      set_cdn_url "https://awesome.com"
-
-      helper.request.env["HTTP_ACCEPT_ENCODING"] = 'br'
-      link = helper.preload_script('application')
-
-      expect(link).to eq(preload_link("https://awesome.com/brotli_asset/application.js"))
-    end
-
-    context "with s3 CDN" do
+    context "enable_experimental_javascript_defer is true" do
       before do
-        global_setting :s3_bucket, 'test_bucket'
-        global_setting :s3_region, 'ap-australia'
-        global_setting :s3_access_key_id, '123'
-        global_setting :s3_secret_access_key, '123'
-        global_setting :s3_cdn_url, 'https://s3cdn.com'
+        SiteSetting.enable_experimental_javascript_defer = true
       end
 
-      it "deals correctly with subfolder" do
-        set_subfolder "/community"
-        expect(helper.preload_script("application")).to include('https://s3cdn.com/assets/application.js')
+      it "returns defer tag as default" do
+        expect(helper.preload_script("application")).to include(' defer ')
       end
 
-      it "replaces cdn URLs with s3 cdn subfolder paths" do
-        global_setting :s3_cdn_url, 'https://s3cdn.com/s3_subpath'
+      it "returns defer tag when forced true" do
+        expect(helper.preload_script("application", true)).to include(' defer ')
+      end
+
+      it "returns no defer tag when forced false" do
+        expect(helper.preload_script("application", false)).not_to include(' defer ')
+      end
+    end
+
+    context "enable_experimental_javascript_defer is false" do
+      before do
+        SiteSetting.enable_experimental_javascript_defer = false
+      end
+
+      def preload_link(url)
+        <<~HTML
+            <link rel="preload" href="#{url}" as="script">
+            <script src="#{url}"></script>
+        HTML
+      end
+
+      it "returns no defer tag as default" do
+        expect(helper.preload_script("application")).not_to include(' defer')
+      end
+
+      it "returns no defer tag when forced true" do
+        expect(helper.preload_script("application", true)).not_to include(' defer')
+      end
+
+      it "returns no defer tag when forced false" do
+        expect(helper.preload_script("application", false)).not_to include(' defer')
+      end
+
+      it "provides brotli links to brotli cdn" do
         set_cdn_url "https://awesome.com"
-        set_subfolder "/community"
-        expect(helper.preload_script("application")).to include('https://s3cdn.com/s3_subpath/assets/application.js')
-      end
-
-      it "returns magic brotli mangling for brotli requests" do
 
         helper.request.env["HTTP_ACCEPT_ENCODING"] = 'br'
         link = helper.preload_script('application')
 
-        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.br.js"))
+        expect(link).to eq(preload_link("https://awesome.com/brotli_asset/application.js"))
       end
 
-      it "gives s3 cdn if asset host is not set" do
-        link = helper.preload_script('application')
+      context "with s3 CDN" do
+        before do
+          global_setting :s3_bucket, 'test_bucket'
+          global_setting :s3_region, 'ap-australia'
+          global_setting :s3_access_key_id, '123'
+          global_setting :s3_secret_access_key, '123'
+          global_setting :s3_cdn_url, 'https://s3cdn.com'
+        end
 
-        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
-      end
+        it "deals correctly with subfolder" do
+          set_subfolder "/community"
+          expect(helper.preload_script("application")).to include('https://s3cdn.com/assets/application.js')
+        end
 
-      it "can fall back to gzip compression" do
-        helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip'
-        link = helper.preload_script('application')
-        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.gz.js"))
-      end
+        it "replaces cdn URLs with s3 cdn subfolder paths" do
+          global_setting :s3_cdn_url, 'https://s3cdn.com/s3_subpath'
+          set_cdn_url "https://awesome.com"
+          set_subfolder "/community"
+          expect(helper.preload_script("application")).to include('https://s3cdn.com/s3_subpath/assets/application.js')
+        end
 
-      it "gives s3 cdn even if asset host is set" do
-        set_cdn_url "https://awesome.com"
-        link = helper.preload_script('application')
+        it "returns magic brotli mangling for brotli requests" do
 
-        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
-      end
+          helper.request.env["HTTP_ACCEPT_ENCODING"] = 'br'
+          link = helper.preload_script('application')
 
-      it "gives s3 cdn but without brotli/gzip extensions for theme tests assets" do
-        helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip, br'
-        link = helper.preload_script('discourse/tests/theme_qunit_ember_jquery')
-        expect(link).to eq(preload_link("https://s3cdn.com/assets/discourse/tests/theme_qunit_ember_jquery.js"))
+          expect(link).to eq(preload_link("https://s3cdn.com/assets/application.br.js"))
+        end
+
+        it "gives s3 cdn if asset host is not set" do
+          link = helper.preload_script('application')
+
+          expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
+        end
+
+        it "can fall back to gzip compression" do
+          helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip'
+          link = helper.preload_script('application')
+          expect(link).to eq(preload_link("https://s3cdn.com/assets/application.gz.js"))
+        end
+
+        it "gives s3 cdn even if asset host is set" do
+          set_cdn_url "https://awesome.com"
+          link = helper.preload_script('application')
+
+          expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
+        end
+
+        it "gives s3 cdn but without brotli/gzip extensions for theme tests assets" do
+          helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip, br'
+          link = helper.preload_script('discourse/tests/theme_qunit_ember_jquery')
+          expect(link).to eq(preload_link("https://s3cdn.com/assets/discourse/tests/theme_qunit_ember_jquery.js"))
+        end
       end
     end
   end


### PR DESCRIPTION
Implement experimental feature flags for "static topic content" and " javascript defer"

### static topic content

`SiteSetting.enable_experimental_static_topic_content`

Can be set via settings dashboard.

Show static content in topic view for a faster Largest Contentful Paint (LCP).
Warning: visitors might see disconcerting jumping of content!"

### javascript defer

`SiteSetting.enable_experimental_javascript_defer`

**Important:** Must be set via rails console and then needs a theme cache flush and rails restart or alternatively a container rebuild.

Defer loading of JavaScripts to show static content even faster in combination with 'enable_experimental_javascript_defer'. Warning: the discourse frontend, themes, components and/or plugins might fail!

---

How to clear theme cache to apply - e.g. via rails console:

```ruby
ThemeField.force_recompilation!
Theme.expire_site_cache!
Stylesheet::Manager.cache.clear
```

@see:
https://github.com/discourse/discourse/blob/e2c415457c6527680129475c07458401a54c08e0/lib/backup_restore/restorer.rb#L170-L174

---

The vendor-javascript and all preceding javascripts are not deferred right now.
@see: https://github.com/rr-it/discourse/commit/49405c353a31180933aed9dca7697dce05227707
Ideas on how to solve this are very welcome.

---

For more information see also:
https://meta.discourse.org/t/defer-javascript-and-show-interim-content-on-initial-page-load/216458