### PR TITLE
FIX: set microdata schema for topic on missing first post

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -50,7 +50,7 @@
         <% end %>
       </div>
 
-      <% if @topic_view.prev_page %>
+      <% if @topic_view.posts&.first && !@topic_view.posts.first.is_first_post? %>
         <meta itemprop='datePublished' content='<%= @topic_view.topic.created_at.to_formatted_s(:iso8601) %>'>
         <span itemprop='author' itemscope itemtype="http://schema.org/Person">
           <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>


### PR DESCRIPTION
Some attributes of the microdata schema `DiscussionForumPosting` are rendered in the context of the first post. Ensure these attributes are also set if the first post is not part of the current view.